### PR TITLE
Check state of enable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysfs-pwm"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/posborne/rust-sysfs-pwm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,17 @@ impl Pwm {
         Ok(())
     }
 
+    /// Query the state of enable for a given PWM pin
+    pub fn get_enabled(&self) -> Result<bool> {
+        pwm_file_parse::<u32>(&self.chip, self.number, "enable").map(|enable_state| {
+            match enable_state {
+                1 => true,
+                0 => false,
+                _ => panic!("enable != 1|0 should be unreachable")
+            }
+        })
+    }
+
     /// Get the currently configured duty_cycle in nanoseconds
     pub fn get_duty_cycle_ns(&self) -> Result<u32> {
         pwm_file_parse::<u32>(&self.chip, self.number, "duty_cycle")


### PR DESCRIPTION
Thanks for the work @posborne!

In the current implementation `enable` is write-only.  This adds a simple getter for checking the state of `enable.`