### PR TITLE
Added get_duty_cycle and set_duty_cycle functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,19 @@ impl Pwm {
         Ok(())
     }
 
+    /// Get the currently configured duty_cycle as percentage of period
+    pub fn get_duty_cycle(&self) -> Result<f32> {
+        Ok((self.get_duty_cycle_ns()? as f32) / (self.get_period_ns()? as f32))
+    }
+
+    /// The active time of the PWM signal
+    ///
+    /// Value is as percentage of period.
+    pub fn set_duty_cycle(&self, duty_cycle: f32) -> Result<()> {
+        self.set_duty_cycle_ns((self.get_period_ns()? as f32 * duty_cycle).round() as u32)?;
+        Ok(())
+    }
+
     /// Get the currently configured period in nanoseconds
     pub fn get_period_ns(&self) -> Result<u32> {
         pwm_file_parse::<u32>(&self.chip, self.number, "period")


### PR DESCRIPTION
`README.md` documents functions `get_duty_cycle` and `set_duty_cycle` but does not contain its implementations.
This pull request should fix that.