### PR TITLE
Use f64 for increased precision

### DIFF
--- a/examples/breathe.rs
+++ b/examples/breathe.rs
@@ -17,22 +17,22 @@ const BB_PWM_CHIP: u32 = 0;
 const BB_PWM_NUMBER: u32 = 0;
 
 fn pwm_increase_to_max(pwm: &Pwm, duration_ms: u32, update_period_ms: u32) -> Result<()> {
-    let step: f32 = duration_ms as f32 / update_period_ms as f32;
+    let step: f64 = duration_ms as f64 / update_period_ms as f64;
     let mut duty_cycle = 0.0;
     let period_ns: u32 = pwm.get_period_ns()?;
     while duty_cycle < 1.0 {
-        pwm.set_duty_cycle_ns((duty_cycle * period_ns as f32) as u32)?;
+        pwm.set_duty_cycle_ns((duty_cycle * period_ns as f64) as u32)?;
         duty_cycle += step;
     }
     pwm.set_duty_cycle_ns(period_ns)
 }
 
 fn pwm_decrease_to_minimum(pwm: &Pwm, duration_ms: u32, update_period_ms: u32) -> Result<()> {
-    let step: f32 = duration_ms as f32 / update_period_ms as f32;
+    let step: f64 = duration_ms as f64 / update_period_ms as f64;
     let mut duty_cycle = 1.0;
     let period_ns: u32 = pwm.get_period_ns()?;
     while duty_cycle > 0.0 {
-        pwm.set_duty_cycle_ns((duty_cycle * period_ns as f32) as u32)?;
+        pwm.set_duty_cycle_ns((duty_cycle * period_ns as f64) as u32)?;
         duty_cycle -= step;
     }
     pwm.set_duty_cycle_ns(0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,15 +220,15 @@ impl Pwm {
     }
 
     /// Get the currently configured duty_cycle as percentage of period
-    pub fn get_duty_cycle(&self) -> Result<f32> {
-        Ok((self.get_duty_cycle_ns()? as f32) / (self.get_period_ns()? as f32))
+    pub fn get_duty_cycle<F>(&self) -> Result<f64> {
+        Ok((self.get_duty_cycle_ns()? as f64) / (self.get_period_ns()? as f64))
     }
 
     /// The active time of the PWM signal
     ///
     /// Value is as percentage of period.
-    pub fn set_duty_cycle(&self, duty_cycle: f32) -> Result<()> {
-        self.set_duty_cycle_ns((self.get_period_ns()? as f32 * duty_cycle).round() as u32)?;
+    pub fn set_duty_cycle(&self, duty_cycle: f64) -> Result<()> {
+        self.set_duty_cycle_ns((self.get_period_ns()? as f64 * duty_cycle).round() as u32)?;
         Ok(())
     }
 


### PR DESCRIPTION
`f32` use 23 bits for the fractional part. But it's not enough to cover the full `u32` range provided by the kernel.